### PR TITLE
Added the ability to use templates to present results

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Full Props
     class-name="custom class name"
     placeholder="placeholder"
     :init-value="initial value"
-    :init-value="initial value"
+    :debounce="250"
+    :process="function"
+    :template="function"
     :custom-params="{ token: 'dev' }"
     :min="3"
 
@@ -149,6 +151,14 @@ Custom class name for autocomplete component
 #### id (String)
 Custom id name for autocomplete component
 
+#### debounce (number)
+Number of milliseconds the user should stop typing for before the request is sent. Default is 0, meaning all requests are sent immediately.
+
+#### process (Function)
+Function to process the API result with. Should return an array of entries or an object whose properties can be enumerated.
+
+#### template (Function)
+Function to process each result with. Takes the type of an API reply element and should return HTML data.
 
 
 ## Callback Events

--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -18,14 +18,17 @@
         <li v-for="(data, i) in json"
             transition="showAll"
             :class="activeClass(i)">
-
-          <a  href="#"
+          <a v-if="!template" href="#"
               @click.prevent="selectList(data)"
               @mousemove="mousemove(i)">
             <b>{{ data[anchor] }}</b>
             <span>{{ data[label] }}</span>
           </a>
-
+          <a v-if="template" href="#"
+            @click.prevent="selectList(data)"
+            @mousemove="mousemove(i)"
+            v-html="template(data)">
+          </a>
         </li>
       </ul>
     </div>
@@ -84,6 +87,9 @@
         type: Number,
         default: 0
       },
+
+      // Create a custom template from data.
+      template: Function,
 
       // Callback
       onInput: Function,
@@ -241,7 +247,6 @@
 
           ajax.addEventListener('progress', function (data) {
             if(data.lengthComputable){
-
               // Callback Event
               this.onAjaxProgress ? this.onAjaxProgress(data) : null
             }


### PR DESCRIPTION
# Scope

This pull request adds a new parameter, `template`, which takes a function.

This function is applied on the entries and should return raw HTML. This HTML will be used to present the results.

If this function is not used, then the previous behavior will be used.

## Code

```html
<autocomplete
    :template="getHTML" >
</autocomplete>
```
```js
methods: {
    getHTML(data) {
        return `<span>${data.name}</span><span>${data.count}</span>`;
    }
}
```