### PR TITLE
Add properties to set the class of input and div wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Full Props
 
     id="custom id"
     class-name="custom class name"
+    wrapperClass="custom class name"
+    inputClass="custom class name"
+    listClass="custom class name"
     placeholder="placeholder"
     :init-value="initial value"
     :init-value="initial value"
@@ -144,7 +147,16 @@ Same as anchor but it's used for subtitle or description of list
 Placeholder for input
 
 #### className (String)
-Custom class name for autocomplete component
+Custom class name for autocomplete component. Prefer using `inputClass`, `wrapperClass` or `listClass`.
+
+#### inputClass (String)
+Custom class name for autocomplete input tag.
+
+#### wrapperClass (String)
+Custom class name for autocomplete div tag surrounding the content.
+
+#### listClass (String)
+Custom class name for autocomplete div tag sourrounding the results list.
 
 #### id (String)
 Custom id name for autocomplete component

--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -1,9 +1,9 @@
 
 <template>
-  <div :class="(className ? className + '-wrapper ' : '') + (wrapperClassName ? wrapperClassName + ' ' : '') + 'autocomplete-wrapper'">
+  <div :class="(className ? className + '-wrapper ' : '') + (wrapperClass ? wrapperClass + ' ' : '') + 'autocomplete-wrapper'">
     <input  type="text"
             :id="id"
-            :class="(className ? className + '-input ' : '') + (inputClassName ? inputClassName + ' ' : '') + 'autocomplete-input'"
+            :class="(className ? className + '-input ' : '') + (inputClass ? inputClass + ' ' : '') + 'autocomplete-input'"
             :placeholder="placeholder"
             v-model="type"
             @input="input(type)"
@@ -13,7 +13,7 @@
             @focus="focus"
             autocomplete="off" />
 
-    <div :class="(className ? className + '-list ' : '') + 'autocomplete transition autocomplete-list'" v-show="showList">
+    <div :class="(className ? className + '-list ' : '') + (listClass ? listClass + ' ' : '') + 'autocomplete transition autocomplete-list'" v-show="showList">
       <ul>
         <li v-for="(data, i) in json"
             transition="showAll"
@@ -46,8 +46,9 @@
 
     props: {
       id: String,
-      wrapperClassName: String,
-      inputClassName: String,
+      wrapperClass: String,
+      inputClass: String,
+      listClass: String,
       className: String,
       placeholder: String,
 

--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -1,6 +1,6 @@
 
 <template>
-  <div :class="(className ? className + '-wrapper ' : '') + 'autocomplete-wrapper'">
+  <div :class="(className ? className + '-wrapper ' : '') + (wrapperClassName ? wrapperClassName + ' ' : '') + 'autocomplete-wrapper'">
     <input  type="text"
             :id="id"
             :class="(className ? className + '-input ' : '') + (inputClassName ? inputClassName + ' ' : '') + 'autocomplete-input'"
@@ -46,6 +46,7 @@
 
     props: {
       id: String,
+      wrapperClassName: String,
       inputClassName: String,
       className: String,
       placeholder: String,

--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -3,7 +3,7 @@
   <div :class="(className ? className + '-wrapper ' : '') + 'autocomplete-wrapper'">
     <input  type="text"
             :id="id"
-            :class="(className ? className + '-input ' : '') + 'autocomplete-input'"
+            :class="(className ? className + '-input ' : '') + (inputClassName ? inputClassName + ' ' : '') + 'autocomplete-input'"
             :placeholder="placeholder"
             v-model="type"
             @input="input(type)"
@@ -46,6 +46,7 @@
 
     props: {
       id: String,
+      inputClassName: String,
       className: String,
       placeholder: String,
 


### PR DESCRIPTION
# Scope

Solves #3 

Adds a `wrapperClass`, `inputClass` and `listClass` parameter to set the wrapper, input and list classes respectively.

## Code

```html
<autocomplete
    inputClass="input"
    wrapperClass="wrapper"
    listClass="list">
</autocomplete>
```