### PR TITLE
Added 'name' attribute

### DIFF
--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -3,6 +3,7 @@
   <div :class="(className ? className + '-wrapper ' : '') + 'autocomplete-wrapper'">
     <input  type="text"
             :id="id"
+            :name="name"
             :class="(className ? className + '-input ' : '') + 'autocomplete-input'"
             :placeholder="placeholder"
             v-model="type"
@@ -69,6 +70,7 @@
 
     props: {
       id: String,
+      name: String,
       className: String,
       placeholder: String,
 


### PR DESCRIPTION
Sometimes is necesary add the 'name' attribute on the Input element, in order to send it as form field.