### PR TITLE
Remove the input css class from list item

### DIFF
--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -299,7 +299,7 @@
 
       activeClass(i){
         const focusClass = i === this.focusList ? 'focus-list' : ''
-        return `${this.getClassName('input')} ${focusClass}`
+        return `${focusClass}`
       },
 
       selectList(data){


### PR DESCRIPTION
I added the `form-control` class via `:classes="{input: 'form-control'}"` to the input field. This works very well for the input but unfortunately this adds the class also to every `<li>` tag. As a result every item is rendered as a input field.

Current behavior:
<img width="451" alt="screen shot 2017-08-23 at 19 21 25" src="https://user-images.githubusercontent.com/363363/29629363-c8f1396c-8838-11e7-90c1-4096c6ef4ef9.png">

Expected behavior:
<img width="461" alt="screen shot 2017-08-23 at 19 26 06" src="https://user-images.githubusercontent.com/363363/29629420-05193106-8839-11e7-9776-f10c84e3a487.png">
