### PR TITLE
apply item classes to <li>

### DIFF
--- a/src/js/components/vue-autocomplete.vue
+++ b/src/js/components/vue-autocomplete.vue
@@ -24,7 +24,7 @@
       <ul>
         <li
           v-for="(data, i) in json"
-          :class="activeClass(i)"
+          :class="`${getClassName('item')} ${activeClass(i)}`"
         >
           <a
             href="#"


### PR DESCRIPTION
I noticed the item classes don't get applied to the <li>. 
This will fix that, and still keeps the active classes applied 