### PR TITLE
Fix forbid Chinese input issue

### DIFF
--- a/dist/vue2-autocomplete.js
+++ b/dist/vue2-autocomplete.js
@@ -683,7 +683,8 @@ var render = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._sel
     },
     on: {
       "input": [function($event) {
-        if ($event.target.composing) { return; }
+        // This line would forbit Chines input
+        // if ($event.target.composing) { return; }
         _vm.type = $event.target.value
       }, _vm.handleInput],
       "dblclick": _vm.handleDoubleClick,


### PR DESCRIPTION
`line 686` in file `dist/vue2-autocomplete.js` will forbit the Chinese input.
```
      if ($event.target.composing) { return; }
```

I comment this line out to make Chinese input successfully. And have not found side effect without this line.
If without this line won't cause error, merge this PR please.